### PR TITLE
Fix: install pangocairo system deps for cdl-slides CI

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install system dependencies for cdl-slides
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpango1.0-dev libcairo2-dev pkg-config
+
       - name: Install cdl-slides
         run: pip install "cdl-slides>=1.2.0"
 


### PR DESCRIPTION
## Summary

- Install `libpango1.0-dev` and `libcairo2-dev` before `pip install cdl-slides` in the deploy workflow
- These are required by `manimpango` (a transitive dependency: cdl-slides → manim → manimpango → pangocairo)

## Test plan

- [ ] Deploy Course Site workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)